### PR TITLE
Do not call yum update in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ FROM       centos:centos7
 
 # Pull in important updates and then install ruby193
 #
-RUN yum update -y --enablerepo=centosplus && \
-    yum install -y --enablerepo=centosplus \
+RUN yum install -y --enablerepo=centosplus \
     gettext tar which ruby ruby-devel \
     rubygem-bundler rubygem-rake \
     gcc-c++ automake make autoconf curl-devel openssl-devel \


### PR DESCRIPTION
@smarterclayton @soltysh  fyi. I'm also going to make PR for the wildfly image.

For others:

We should not try to yum update on every build, but rather keep the base image vendor (centos) to provide the base image updates.
